### PR TITLE
SFX-158: Add CACHE_RESPONSE_PREFIX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `AUTOCOMPLETE_RESPONSE`
     - `CACHE_ERROR`
     - `CACHE_REQUEST`
+    - `CACHE_RESPONSE_PREFIX`
     - `SAYT_HIDE`
     - `SAYT_SHOW`
     - `SEARCHBOX_CLEARED`

--- a/src/cache/cache.ts
+++ b/src/cache/cache.ts
@@ -17,7 +17,7 @@ export interface CacheResponsePayload extends WithGroup {
   /** The name of the cached data that was returned. */
   name: string;
   /** The data that was cached. */
-  data: string;
+  data: any;
 }
 
 /** The name of the event fired when retrieving data from the cache failed. */

--- a/src/cache/cache.ts
+++ b/src/cache/cache.ts
@@ -10,6 +10,8 @@ export interface CacheRequestPayload extends WithGroup {
   returnEvent: string;
 }
 
+/** The recommended prefix to use for the name of the event fired when data is returned from the cache. */
+export const CACHE_RESPONSE_PREFIX = 'sfx::cache_response-';
 /** The type of the cache response event payload. */
 export interface CacheResponsePayload extends WithGroup {
   /** The name of the cached data that was returned. */


### PR DESCRIPTION
Add a recommended prefix to use for cache response events so that library users have a pattern to follow. This makes bugs related to caches easier to trace.

Also correct the type of the response data from `string` to `any`.