### PR TITLE
ELE-519: Make Search and SAYT products response structures match

### DIFF
--- a/src/sayt/products.ts
+++ b/src/sayt/products.ts
@@ -17,8 +17,14 @@ export const SAYT_PRODUCTS_RESPONSE = 'gbe::sayt_products_response';
  * @typeparam P The type of a product in the payload.
  */
 export interface SaytProductsResponsePayload<P> extends WithGroup {
-  products: P[];
+  /**
+   * The original, unformatted response from the API.
+   */
   originalResponse: Results;
+  /**
+   * The formatted products results.
+   */
+  products: P[];
 }
 
 /** The name of the event fired when a SAYT products request fails. */

--- a/src/sayt/products.ts
+++ b/src/sayt/products.ts
@@ -17,13 +17,9 @@ export const SAYT_PRODUCTS_RESPONSE = 'gbe::sayt_products_response';
  * @typeparam P The type of a product in the payload.
  */
 export interface SaytProductsResponsePayload<P> extends WithGroup {
-  /**
-   * The original, unformatted response from the API.
-   */
+  /** The original, unformatted response from the Search API. */
   originalResponse: Results;
-  /**
-   * The formatted products results.
-   */
+  /** The formatted products results. */
   products: P[];
 }
 

--- a/src/search/search.ts
+++ b/src/search/search.ts
@@ -13,22 +13,19 @@ export interface SearchRequestPayload extends WithQuery, WithGroup {
 export const SEARCH_RESPONSE = 'gbe::search_response';
 
 /**
- * The type of the results within a search response payload.
- *
- * @typeparam P The type of a product in the response.
- */
-export interface SearchResponseSection<P> {
-  originalResponse: Results;
-  products: P[];
-}
-
-/**
  * The type of the [[SEARCH_RESPONSE]] event payload.
  *
  * @typeparam P The type of a product in the payload.
  */
 export interface SearchResponsePayload<P> extends WithGroup {
-  results: SearchResponseSection<P>;
+  /**
+   * The original, unformatted response from the API.
+   */
+  originalResponse: Results;
+  /**
+   * The formatted products results.
+   */
+  products: P[];
 }
 
 /** The name of the event fired when a search request fails. */

--- a/src/search/search.ts
+++ b/src/search/search.ts
@@ -18,13 +18,9 @@ export const SEARCH_RESPONSE = 'gbe::search_response';
  * @typeparam P The type of a product in the payload.
  */
 export interface SearchResponsePayload<P> extends WithGroup {
-  /**
-   * The original, unformatted response from the API.
-   */
+  /** The original, unformatted response from the Search API. */
   originalResponse: Results;
-  /**
-   * The formatted products results.
-   */
+  /** The formatted products results. */
   products: P[];
 }
 


### PR DESCRIPTION
Search and SAYT drivers send their product responses out with different formats. This was originally done before we decided to go with transformers as a data transformation solution. This is also getting in the way now and is confusing for development. 