### PR TITLE
ELE-249: Create first pass of tracker service plugin for Search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - SFX-249: Create first pass of tracker service plugin for Search
   - Added `origin` to:
-    - SaytProductsRequestPayload
-    - SearchRequestPayload
-    - UpdateSearchTermPayload
+    - `SaytProductsRequestPayload`
+    - `SearchRequestPayload`
+    - `UpdateSearchTermPayload`
 
 ### Added
 - SFX-249: Create first pass of tracker service plugin for Search

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,20 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] [minor]
 ### Changed
-- SFX-249: Created tracker service plugin for Search
-  - Added `origin` to:
-    - `SaytProductsRequestPayload`
-    - `SearchRequestPayload`
-    - `UpdateSearchTermPayload`
+- ELE-249: Added a required `origin` property to the following interfaces:
+  - `SaytProductsRequestPayload`
+  - `SearchRequestPayload`
+  - `UpdateSearchTermPayload`
 
 ### Added
-- SFX-249: Created tracker service plugin for Search
-  - Event name constants:
-    - `BEACON_SEARCH`
-  - Event payload interfaces:
-    - `BeaconSearchPayload`
-  - Dependencies:
-    - `gb-tracker-client`
+- ELE-249: Added search beacon-related event.
+  - Event name constant: `BEACON_SEARCH`
+  - Event payload interface: `BeaconSearchPayload`
+- ELE-249: Added `gb-tracker-client` as a dependency.
 
 ## [0.1.0] - 2019-11-28
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `SEARCH_ERROR`
     - `SEARCH_REQUEST`
     - `SEARCH_RESPONSE`
+    - `TRACKER_SEARCH`
     - `UPDATE_SEARCH_TERM`
   - Event payload interfaces:
     - `AutocompleteErrorPayload`
@@ -44,4 +45,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `SearchboxClearedPayload`
     - `SearchboxClickPayload`
     - `SearchboxInputPayload`
+    - `TrackerSearchPayload`
     - `UpdateSearchTermPayload`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2019-12-06
+### Added
+- SFX-249: Create first pass of tracker service plugin for Search
+  - Event name constants:
+    - `BEACON_SEARCH`
+  - Event payload interfaces:
+    - `BeaconSearchPayload`
+  - Dependencies:
+    - `gb-tracker-client`
+
+### Changed
+- SFX-249: Create first pass of tracker service plugin for Search
+  - Added `origin` to:
+    - SaytProductsRequestPayload
+    - SearchRequestPayload
+    - UpdateSearchTermPayload
+
 ## [0.1.0] - 2019-11-28
 ### Added
 - SFX-248: Added a number of event names and interfaces used by GB Elements.
@@ -22,7 +39,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `SEARCH_ERROR`
     - `SEARCH_REQUEST`
     - `SEARCH_RESPONSE`
-    - `TRACKER_SEARCH`
     - `UPDATE_SEARCH_TERM`
   - Event payload interfaces:
     - `AutocompleteErrorPayload`
@@ -45,5 +61,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `SearchboxClearedPayload`
     - `SearchboxClickPayload`
     - `SearchboxInputPayload`
-    - `TrackerSearchPayload`
     - `UpdateSearchTermPayload`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2019-12-06
+## [Unreleased] [minor]
+### Changed
+- SFX-249: Create first pass of tracker service plugin for Search
+  - Added `origin` to:
+    - SaytProductsRequestPayload
+    - SearchRequestPayload
+    - UpdateSearchTermPayload
+
 ### Added
 - SFX-249: Create first pass of tracker service plugin for Search
   - Event name constants:
@@ -20,6 +27,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - SaytProductsRequestPayload
     - SearchRequestPayload
     - UpdateSearchTermPayload
+
+### Added
+- SFX-249: Create first pass of tracker service plugin for Search
+  - Event name constants:
+    - `BEACON_SEARCH`
+  - Event payload interfaces:
+    - `BeaconSearchPayload`
+  - Dependencies:
+    - `gb-tracker-client`
 
 ## [0.1.0] - 2019-11-28
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] [minor]
 ### Changed
-- SFX-249: Create first pass of tracker service plugin for Search
+- SFX-249: Created tracker service plugin for Search
   - Added `origin` to:
     - `SaytProductsRequestPayload`
     - `SearchRequestPayload`
     - `UpdateSearchTermPayload`
 
 ### Added
-- SFX-249: Create first pass of tracker service plugin for Search
+- SFX-249: Created tracker service plugin for Search
   - Event name constants:
     - `BEACON_SEARCH`
   - Event payload interfaces:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,22 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Dependencies:
     - `gb-tracker-client`
 
-### Changed
-- SFX-249: Create first pass of tracker service plugin for Search
-  - Added `origin` to:
-    - SaytProductsRequestPayload
-    - SearchRequestPayload
-    - UpdateSearchTermPayload
-
-### Added
-- SFX-249: Create first pass of tracker service plugin for Search
-  - Event name constants:
-    - `BEACON_SEARCH`
-  - Event payload interfaces:
-    - `BeaconSearchPayload`
-  - Dependencies:
-    - `gb-tracker-client`
-
 ## [0.1.0] - 2019-11-28
 ### Added
 - SFX-248: Added a number of event names and interfaces used by GB Elements.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
+    "gb-tracker-client": "^3.7.2",
     "groupby-api": "^2.6.2",
     "sayt": "^0.1.9"
   }

--- a/src/beacons/beacons.ts
+++ b/src/beacons/beacons.ts
@@ -1,13 +1,14 @@
 import { Results } from 'groupby-api';
+import { SendableOrigin } from 'gb-tracker-client/models';
 
 /** The event to trigger a search beacon. */
-export const TrackerSearchEvent: string = 'gbe::tracker::search';
+export const TRACKER_SEARCH: string = 'gbe::tracker::search';
 
 /**
  * The type of the [[TrackerSearchEvent]] event payload.
  */
 export interface TrackerSearchPayload {
-  /** The search results. */
+  /** The search results from the API. */
   results: Results;
   /** The origin of the search action. */
   origin: SendableOrigin;

--- a/src/beacons/beacons.ts
+++ b/src/beacons/beacons.ts
@@ -1,0 +1,14 @@
+import { Results } from 'groupby-api';
+
+/** The event to trigger a search beacon. */
+export const TrackerSearchEvent: string = 'gbe::tracker::search';
+
+/**
+ * The type of the [[TrackerSearchEvent]] event payload.
+ */
+export interface TrackerSearchPayload {
+  /** The search results. */
+  results: Results;
+  /** The origin of the search action. */
+  origin: SendableOrigin;
+}

--- a/src/beacons/beacons.ts
+++ b/src/beacons/beacons.ts
@@ -5,7 +5,7 @@ import { SendableOrigin } from 'gb-tracker-client/models';
 export const TRACKER_SEARCH: string = 'gbe::tracker::search';
 
 /**
- * The type of the [[TrackerSearchEvent]] event payload.
+ * The type of the [[TRACKER_SEARCH]] event payload.
  */
 export interface TrackerSearchPayload {
   /** The search results from the API. */

--- a/src/beacons/beacons.ts
+++ b/src/beacons/beacons.ts
@@ -5,7 +5,7 @@ import { SendableOrigin } from 'gb-tracker-client/models';
 export const BEACON_SEARCH: string = 'gbe::beacon::search';
 
 /** The type of the [[BEACON_SEARCH]] event payload. */
-export interface TrackerSearchPayload {
+export interface BeaconSearchPayload {
   /** The search results from the API. */
   results: Results;
   /** The origin of the search action. */

--- a/src/beacons/beacons.ts
+++ b/src/beacons/beacons.ts
@@ -2,7 +2,7 @@ import { Results } from 'groupby-api';
 import { SendableOrigin } from 'gb-tracker-client/models';
 
 /** The event to trigger a search beacon. */
-export const BEACON_SEARCH: string = 'gbe::beacon::search';
+export const BEACON_SEARCH: string = 'gbe::beacon_search';
 
 /** The type of the [[BEACON_SEARCH]] event payload. */
 export interface BeaconSearchPayload {

--- a/src/beacons/beacons.ts
+++ b/src/beacons/beacons.ts
@@ -1,5 +1,5 @@
-import { Results } from 'groupby-api';
 import { SendableOrigin } from 'gb-tracker-client/models';
+import { Results } from 'groupby-api';
 
 /** The event to trigger a search beacon. */
 export const BEACON_SEARCH: string = 'gbe::beacon_search';

--- a/src/beacons/beacons.ts
+++ b/src/beacons/beacons.ts
@@ -2,9 +2,9 @@ import { Results } from 'groupby-api';
 import { SendableOrigin } from 'gb-tracker-client/models';
 
 /** The event to trigger a search beacon. */
-export const TRACKER_SEARCH: string = 'gbe::tracker::search';
+export const BEACON_SEARCH: string = 'gbe::beacon::search';
 
-/** The type of the [[TRACKER_SEARCH]] event payload. */
+/** The type of the [[BEACON_SEARCH]] event payload. */
 export interface TrackerSearchPayload {
   /** The search results from the API. */
   results: Results;

--- a/src/beacons/beacons.ts
+++ b/src/beacons/beacons.ts
@@ -4,9 +4,7 @@ import { SendableOrigin } from 'gb-tracker-client/models';
 /** The event to trigger a search beacon. */
 export const TRACKER_SEARCH: string = 'gbe::tracker::search';
 
-/**
- * The type of the [[TRACKER_SEARCH]] event payload.
- */
+/** The type of the [[TRACKER_SEARCH]] event payload. */
 export interface TrackerSearchPayload {
   /** The search results from the API. */
   results: Results;

--- a/src/beacons/index.ts
+++ b/src/beacons/index.ts
@@ -1,0 +1,1 @@
+export * from './beacons';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './includes';
+export * from './beacons';
 export * from './cache';
 export * from './sayt';
 export * from './search';

--- a/src/sayt/products.ts
+++ b/src/sayt/products.ts
@@ -1,4 +1,5 @@
 import { Request, Results } from 'groupby-api';
+import { SendableOrigin } from 'gb-tracker-client/models';
 import { ErrorPayload, Product, WithQuery, WithGroup } from '../includes';
 
 /** The name of the event fired to request SAYT products. */
@@ -8,7 +9,7 @@ export interface SaytProductsRequestPayload extends WithQuery, WithGroup {
   /** The extra configuration options to customize the request. */
   config?: Partial<Request>;
   /** The origin of the products request action. */
-  origin: string;
+  origin: keyof SendableOrigin;
 }
 
 /** The name of the event fired when the results of a SAYT products request have been received. */

--- a/src/sayt/products.ts
+++ b/src/sayt/products.ts
@@ -1,5 +1,5 @@
-import { Request, Results } from 'groupby-api';
 import { SendableOrigin } from 'gb-tracker-client/models';
+import { Request, Results } from 'groupby-api';
 import { ErrorPayload, Product, WithQuery, WithGroup } from '../includes';
 
 /** The name of the event fired to request SAYT products. */

--- a/src/sayt/products.ts
+++ b/src/sayt/products.ts
@@ -7,6 +7,8 @@ export const SAYT_PRODUCTS_REQUEST = 'gbe::sayt_products_request';
 export interface SaytProductsRequestPayload extends WithQuery, WithGroup {
   /** The extra configuration options to customize the request. */
   config?: Partial<Request>;
+  /** The origin of the products request action. */
+  origin: string;
 }
 
 /** The name of the event fired when the results of a SAYT products request have been received. */

--- a/src/search/search.ts
+++ b/src/search/search.ts
@@ -1,3 +1,4 @@
+import { SendableOrigin } from 'gb-tracker-client/models';
 import { Request, Results } from 'groupby-api';
 import { ErrorPayload, WithQuery, WithGroup } from '../includes';
 
@@ -8,7 +9,7 @@ export interface SearchRequestPayload extends WithQuery, WithGroup {
   /** The search request configuration. */
   config?: Partial<Request>;
   /** The origin of the search request action. */
-  origin: string;
+  origin: keyof SendableOrigin;
 }
 
 /** The name of the event fired when the results of a search request have been received.  */

--- a/src/search/search.ts
+++ b/src/search/search.ts
@@ -8,7 +8,7 @@ export const SEARCH_REQUEST = 'gbe::search_request';
 export interface SearchRequestPayload extends WithQuery, WithGroup {
   /** The search request configuration. */
   config?: Partial<Request>;
-  /** The origin of the search action. */
+  /** The origin of the search request action. */
   origin: string;
 }
 

--- a/src/search/search.ts
+++ b/src/search/search.ts
@@ -6,7 +6,10 @@ import { Product } from '../includes/product';
 export const SEARCH_REQUEST = 'gbe::search_request';
 /** The type of the [[SEARCH_REQUEST]] event payload. */
 export interface SearchRequestPayload extends WithQuery, WithGroup {
+  /** The search request configuration. */
   config?: Partial<Request>;
+  /** The origin of the search action. */
+  origin: string;
 }
 
 /** The name of the event fired when the results of a search request have been received.  */

--- a/src/search/search.ts
+++ b/src/search/search.ts
@@ -1,6 +1,5 @@
 import { Request, Results } from 'groupby-api';
 import { ErrorPayload, WithQuery, WithGroup } from '../includes';
-import { Product } from '../includes/product';
 
 /** The name of the event fired to request a search. */
 export const SEARCH_REQUEST = 'gbe::search_request';

--- a/src/search/searchbox.ts
+++ b/src/search/searchbox.ts
@@ -1,3 +1,4 @@
+import { SendableOrigin } from 'gb-tracker-client/models';
 import { WithGroup } from '../includes/group';
 
 /** The name of the event fired when the search term is to be updated. */
@@ -9,7 +10,7 @@ export interface UpdateSearchTermPayload extends WithGroup {
   /** Whether or not to trigger a search. */
   search?: boolean;
   /** The origin of the user action. */
-  origin: string;
+  origin: keyof SendableOrigin;
 }
 
 /** The name of the event fired when the user has changed the text in the search box. */

--- a/src/search/searchbox.ts
+++ b/src/search/searchbox.ts
@@ -8,6 +8,8 @@ export interface UpdateSearchTermPayload extends WithGroup {
   term: string;
   /** Whether or not to trigger a search. */
   search?: boolean;
+  /** The origin of the user action. */
+  origin: string;
 }
 
 /** The name of the event fired when the user has changed the text in the search box. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,15 +2,45 @@
 # yarn lockfile v1
 
 
+"@groupby/beacon-models@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@groupby/beacon-models/-/beacon-models-2.0.3.tgz#d1d80149284090c15cc11723a6c91d73b3e0f12a"
+  integrity sha512-XkD6Y7F1AhyllXL3ZWbrV2EfD9LHiXWkO5vO+Lzo/brK/6REBJK15xcwL2rc2uTeQDXfmjutf0oC/lJFhRBQCQ==
+  dependencies:
+    "@types/lodash" "^4.14.123"
+    lodash "^4.17.11"
+    moment "^2.22.2"
+    regexpu-core "^4.2.0"
+
 "@types/clone@^0.1.30":
   version "0.1.30"
   resolved "https://registry.yarnpkg.com/@types/clone/-/clone-0.1.30.tgz#e7365648c1b42136a59c7d5040637b3b5c83b614"
   integrity sha1-5zZWSMG0ITalnH1QQGN7O1yDthQ=
 
+"@types/cuid@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@types/cuid/-/cuid-1.3.0.tgz#20b0e00ca555df564866bc52d2e251bf90c88db7"
+  integrity sha1-ILDgDKVV31ZIZrxS0uJRv5DIjbc=
+
+"@types/deep-diff@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/deep-diff/-/deep-diff-1.0.0.tgz#7eba3202a99b3a207f758f351f7f86387269fc40"
+  integrity sha512-ENsJcujGbCU/oXhDfQ12mSo/mCBWodT2tpARZKmatoSrf8+cGRCPi0KVj3I0FORhYZfLXkewXu7AoIWqiBLkNw==
+
 "@types/deep-equal@^0.0.30":
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@types/deep-equal/-/deep-equal-0.0.30.tgz#c14df825c9201a1804980e7ebc3ef30e137bb64c"
   integrity sha1-wU34JckgGhgEmA5+vD7zDhN7tkw=
+
+"@types/lodash@^4.14.123":
+  version "4.14.149"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
+  integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
+
+"@types/lz-string@^1.3.33":
+  version "1.3.33"
+  resolved "https://registry.yarnpkg.com/@types/lz-string/-/lz-string-1.3.33.tgz#de2d6105ea7bcaf67dd1d9451d580700d30473fc"
+  integrity sha512-yWj3OnlKlwNpq9+Jh/nJkVAD3ta8Abk2kIRpjWpVkDlAD43tn6Q6xk5hurp84ndcq54jBDBGCD/WcIR0pspG0A==
 
 "@types/minimatch@3.0.3":
   version "3.0.3"
@@ -43,6 +73,11 @@ array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
   integrity sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=
+
+async@^1.5.0:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
+  integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
 
 backbone@^1.4.0:
   version "1.4.0"
@@ -88,12 +123,27 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
+cookies-js@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/cookies-js/-/cookies-js-1.2.3.tgz#03315049e7c52bee3f73186a69167eab0ddb2d31"
+  integrity sha1-AzFQSefFK+4/cxhqaRZ+qw3bLTE=
+
+cuid@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/cuid/-/cuid-2.1.6.tgz#dc3a20b5a7497d36d32c0bf8a2997524c9c796c4"
+  integrity sha512-ZFp7PS6cSYMJNch9fc3tyHdE4T8TDo3Y5qAxb0KSA9mpiYDo7z9ql1CznFuuzxea9STVIDy0tJWm2lYiX2ZU1Q==
+
 debug@^2.1.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
+
+deep-diff@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-1.0.2.tgz#afd3d1f749115be965e89c63edc7abb1506b9c26"
+  integrity sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg==
 
 deep-equal@^1.0.1:
   version "1.0.1"
@@ -221,6 +271,21 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
+
+gb-tracker-client@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/gb-tracker-client/-/gb-tracker-client-3.7.2.tgz#2bdcdb7535705b974a94b128548fbf008ecfd393"
+  integrity sha512-nXAZkOq4UFC2wpFj2COx8wWeM9U12sN5bDCd7sqjJ3vUkfk+tzsM5BXjebXYN+Nx2qD644xuEHcvIkN5os8TPA==
+  dependencies:
+    "@groupby/beacon-models" "^2.0.3"
+    "@types/cuid" "^1.3.0"
+    "@types/deep-diff" "^1.0.0"
+    "@types/lz-string" "^1.3.33"
+    cookies-js "^1.2.3"
+    cuid "^2.1.6"
+    deep-diff "^1.0.2"
+    lz-string "^1.4.4"
+    schema-inspector "^1.6.8"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -390,6 +455,11 @@ jquery@^3.4.1:
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
   integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
+jsesc@~0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
+  integrity sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
+
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
@@ -423,7 +493,7 @@ kind-of@^6.0.0:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
   integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
 
-lodash@^4.17.15:
+lodash@^4.17.11, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -432,6 +502,11 @@ lunr@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.6.tgz#f278beee7ffd56ad86e6e478ce02ab2b98c78dd5"
   integrity sha512-swStvEyDqQ85MGpABCMBclZcLI/pBIlu8FFDtmX197+oEgKloJ67QnB+Tidh0340HmLMs39c4GrkPY3cmkXp6Q==
+
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
 
 marked@^0.7.0:
   version "0.7.0"
@@ -473,6 +548,11 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
   integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
+
+moment@^2.22.2:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
 ms@2.0.0:
   version "2.0.0"
@@ -582,12 +662,48 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
+regenerate-unicode-properties@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz#ef51e0f0ea4ad424b77bf7cb41f3e015c70a3f0e"
+  integrity sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==
+  dependencies:
+    regenerate "^1.4.0"
+
+regenerate@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
+  integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
+
 regex-cache@^0.4.2:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.4.tgz#75bdc58a2a1496cec48a12835bc54c8d562336dd"
   integrity sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==
   dependencies:
     is-equal-shallow "^0.1.3"
+
+regexpu-core@^4.2.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.6.0.tgz#2037c18b327cfce8a6fea2a4ec441f2432afb8b6"
+  integrity sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==
+  dependencies:
+    regenerate "^1.4.0"
+    regenerate-unicode-properties "^8.1.0"
+    regjsgen "^0.5.0"
+    regjsparser "^0.6.0"
+    unicode-match-property-ecmascript "^1.0.4"
+    unicode-match-property-value-ecmascript "^1.1.0"
+
+regjsgen@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.5.1.tgz#48f0bf1a5ea205196929c0d9798b42d1ed98443c"
+  integrity sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg==
+
+regjsparser@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.6.0.tgz#f1e6ae8b7da2bae96c99399b868cd6c933a2ba9c"
+  integrity sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==
+  dependencies:
+    jsesc "~0.5.0"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
@@ -622,6 +738,13 @@ sayt@^0.1.9:
     filter-object "^2.1.0"
     jsonp "^0.2.0"
     qs "^6.2.0"
+
+schema-inspector@^1.6.8:
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/schema-inspector/-/schema-inspector-1.6.8.tgz#b9e53983cc55ff2dbd7b65e3dbe085d9d1285f2a"
+  integrity sha1-ueU5g8xV/y29e2Xj2+CF2dEoXyo=
+  dependencies:
+    async "^1.5.0"
 
 shelljs@^0.8.3:
   version "0.8.3"
@@ -688,6 +811,29 @@ underscore@>=1.8.3, underscore@^1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
   integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
+
+unicode-canonical-property-names-ecmascript@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"
+  integrity sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==
+
+unicode-match-property-ecmascript@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz#8ed2a32569961bce9227d09cd3ffbb8fed5f020c"
+  integrity sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==
+  dependencies:
+    unicode-canonical-property-names-ecmascript "^1.0.4"
+    unicode-property-aliases-ecmascript "^1.0.4"
+
+unicode-match-property-value-ecmascript@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz#5b4b426e08d13a80365e0d657ac7a6c1ec46a277"
+  integrity sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==
+
+unicode-property-aliases-ecmascript@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz#a9cc6cc7ce63a0a3023fc99e341b94431d405a57"
+  integrity sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==
 
 universalify@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
* Add file to contain types relating to Beacons
  * Add `TRACKER_SEARCH` event name constant for triggering search tracking events
  * Add `TrackerSearchPayload` interface
* Add `gb-tracker-client` package as a dependency
* Update the following types to include `origin` property:
  * SaytProductsRequestPayload
  * SearchRequestPayload
  * UpdateSearchTermPayload